### PR TITLE
Fix line drawing for environment grid

### DIFF
--- a/js/core/environment.js
+++ b/js/core/environment.js
@@ -177,12 +177,13 @@ var Environment = function(i, j, width, height, opts) {
     }
 
     this.drawLine = function(ctx, x0, y0, x1, y1){
-    	ctx.strokeStyle = 'gray';
-    	ctx.lineWidth = 1.0;
+        ctx.strokeStyle = 'gray';
+        ctx.lineWidth = 1.0;
+        ctx.beginPath();
         //ctx.translate(0.5, 0.5)
-    	ctx.moveTo(x0+0.5, y0+0.5);
-    	ctx.lineTo(x1+0.5, y1+0.5);
-    	ctx.stroke();
+        ctx.moveTo(x0+0.5, y0+0.5);
+        ctx.lineTo(x1+0.5, y1+0.5);
+        ctx.stroke();
     }
 
     this.randomInitialization();


### PR DESCRIPTION
## Summary
- start a new path before drawing grid lines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6847f5e3b9888325afd910c7fe10e003