### PR TITLE
Fix sound stopping behavior

### DIFF
--- a/js/core/resources.js
+++ b/js/core/resources.js
@@ -18,12 +18,15 @@ let resources = {
         }
     },
 
-    stop: function(name){
+    stop: function(name, unload = false){
 
         let sound = this.musics[name];
 
         if (sound && sound.playing()) {
             sound.stop();
+        }
+
+        if(sound && unload){
             sound.unload();
         }
     },


### PR DESCRIPTION
## Summary
- adjust `resources.stop` to accept an optional `unload` flag
- keep sounds loaded by default so they can be replayed without reloading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6847f5e8e86083259006d88ca59730b7