### PR TITLE
Fix README install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,15 @@ The Wumpus World Simulator is available at following languages:
 
 ## Development
 
-Install dependencies with `npm install`.
+Install dependencies with:
+
+```bash
+npm install
+```
+
 Start a local server using:
 
-```
+```bash
 npm start
 ```
 
@@ -63,7 +68,7 @@ This serves the app on <http://localhost:8080>.
 
 Run tests with:
 
-```
+```bash
 npm test
 ```
 


### PR DESCRIPTION
## Summary
- clarify running `npm install` before starting local server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6847fb32dbcc8325a9671abd22b94099