### PR TITLE
Add Jest tests for core modules

### DIFF
--- a/js/core/environment.js
+++ b/js/core/environment.js
@@ -188,3 +188,7 @@ var Environment = function(i, j, width, height, opts) {
 
     this.randomInitialization();
 };
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = Environment;
+}

--- a/js/core/keys.js
+++ b/js/core/keys.js
@@ -92,14 +92,18 @@ var Keys = function(up, left, right, down, space, enter) {
 	// 	};
 	// };
 
-	return {
-		up: up,
-		left: left,
-		right: right,
-		down: down,
-		space: space,
-		enter: enter,
-		onKeyDown: onKeyDown,
-		onKeyUp: onKeyUp
-	};
+        return {
+                up: up,
+                left: left,
+                right: right,
+                down: down,
+                space: space,
+                enter: enter,
+                onKeyDown: onKeyDown,
+                onKeyUp: onKeyUp
+        };
 };
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = Keys;
+}

--- a/js/core/player.js
+++ b/js/core/player.js
@@ -135,5 +135,9 @@ var Player = function(env, x, y) {
         }else if(this.direction == FACING_TO_RIGHT){
             ctx.drawImage(resources.images['facing_to_right'], this.x, this.y, this.env.width, this.env.height);
         }
-	};
+        };
 };
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = Player;
+}

--- a/tests/environment.test.js
+++ b/tests/environment.test.js
@@ -1,0 +1,53 @@
+const ArrayUtils = require('../js/utils/array-utils');
+// expose globally for environment
+global.ArrayUtils = ArrayUtils;
+const RandomUtils = require('../js/utils/random-utils');
+// expose globally for environment
+global.RandomUtils = RandomUtils;
+const Environment = require('../js/core/environment');
+
+describe('Environment.randomInitialization', () => {
+  test('initializes level and copies structures', () => {
+    const stubLevel = { holes: [[1,1]], wumpus: [[0,2]], golds: [[2,0]] };
+    jest.spyOn(RandomUtils, 'getRandomLevel').mockReturnValue(stubLevel);
+    const env = new Environment(3,3,1,1);
+    expect(env.level).toEqual(stubLevel);
+    expect(env.holes).toEqual(stubLevel.holes);
+    expect(env.wumpus).toEqual(stubLevel.wumpus);
+    expect(env.golds).toEqual(stubLevel.golds);
+    expect(env.visible[0][0]).toBe(1);
+    RandomUtils.getRandomLevel.mockRestore();
+  });
+});
+
+describe('Environment.restart', () => {
+  test('restores from level data', () => {
+    const stubLevel = { holes: [[1,0]], wumpus: [[0,1]], golds: [[0,0]] };
+    jest.spyOn(RandomUtils, 'getRandomLevel').mockReturnValue(stubLevel);
+    const env = new Environment(2,2,1,1);
+    env.holes = [[9,9]];
+    env.wumpus = [[8,8]];
+    env.golds = [[7,7]];
+    env.visible[0][0] = 0;
+    env.restart();
+    expect(env.holes).toEqual(stubLevel.holes);
+    expect(env.wumpus).toEqual(stubLevel.wumpus);
+    expect(env.golds).toEqual(stubLevel.golds);
+    expect(env.visible[0][0]).toBe(1);
+    RandomUtils.getRandomLevel.mockRestore();
+  });
+});
+
+describe('Environment.removeWumpus and removeGold', () => {
+  test('removes wumpus and gold properly', () => {
+    const stubLevel = { holes: [], wumpus: [[0,1]], golds: [[1,0]] };
+    jest.spyOn(RandomUtils, 'getRandomLevel').mockReturnValue(stubLevel);
+    const env = new Environment(2,2,1,1);
+    env.removeWumpus([0,1]);
+    expect(env.wumpus).toEqual([]);
+    expect(env.visible[0][1]).toBe(1);
+    env.removeGold([1,0]);
+    expect(env.golds).toEqual([]);
+    RandomUtils.getRandomLevel.mockRestore();
+  });
+});

--- a/tests/keys.test.js
+++ b/tests/keys.test.js
@@ -1,0 +1,40 @@
+const Keys = require('../js/core/keys');
+
+describe('Keys.onKeyDown', () => {
+  let keys;
+  beforeEach(() => {
+    global.isAlive = true;
+    global.isFinished = false;
+    keys = new Keys();
+  });
+
+  test('left arrow sets left flag', () => {
+    keys.onKeyDown({ keyCode: 37 });
+    expect(keys.left).toBe(true);
+  });
+
+  test('up arrow sets up flag', () => {
+    keys.onKeyDown({ keyCode: 38 });
+    expect(keys.up).toBe(true);
+  });
+
+  test('right arrow sets right flag', () => {
+    keys.onKeyDown({ keyCode: 39 });
+    expect(keys.right).toBe(true);
+  });
+
+  test('down arrow sets down flag', () => {
+    keys.onKeyDown({ keyCode: 40 });
+    expect(keys.down).toBe(true);
+  });
+
+  test('space sets space flag', () => {
+    keys.onKeyDown({ keyCode: 32 });
+    expect(keys.space).toBe(true);
+  });
+
+  test('enter sets enter flag', () => {
+    keys.onKeyDown({ keyCode: 13 });
+    expect(keys.enter).toBe(true);
+  });
+});

--- a/tests/player.test.js
+++ b/tests/player.test.js
@@ -1,0 +1,77 @@
+const ArrayUtils = require('../js/utils/array-utils');
+// expose globally for environment and player
+global.ArrayUtils = ArrayUtils;
+const RandomUtils = require('../js/utils/random-utils');
+global.RandomUtils = RandomUtils;
+// stub resources
+global.resources = { play: jest.fn() };
+const Environment = require('../js/core/environment');
+const Player = require('../js/core/player');
+
+describe('Player.kill', () => {
+  test('returns adjacent wumpus and consumes arrow', () => {
+    const level = { holes: [], wumpus: [[1,0]], golds: [] };
+    jest.spyOn(RandomUtils, 'getRandomLevel').mockReturnValue(level);
+    const env = new Environment(2,2,1,1);
+    const player = new Player(env, 0, 0);
+    player.direction = 4; // FACING_TO_RIGHT
+    player.arrow = 1;
+    const keys = { space: true };
+    const dead = player.kill(keys);
+    expect(dead).toEqual([1,0]);
+    expect(player.arrow).toBe(0);
+    expect(keys.space).toBe(false);
+    expect(global.resources.play).toHaveBeenCalledWith('arrow');
+    RandomUtils.getRandomLevel.mockRestore();
+    global.resources.play.mockClear();
+  });
+
+  test('does nothing when out of arrows', () => {
+    const level = { holes: [], wumpus: [], golds: [] };
+    jest.spyOn(RandomUtils, 'getRandomLevel').mockReturnValue(level);
+    const env = new Environment(2,2,1,1);
+    const player = new Player(env, 0, 0);
+    player.arrow = 0;
+    const keys = { space: true };
+    const dead = player.kill(keys);
+    expect(dead).toBe(false);
+    RandomUtils.getRandomLevel.mockRestore();
+  });
+});
+
+describe('Player.capture', () => {
+  test('captures gold on current cell', () => {
+    const level = { holes: [], wumpus: [], golds: [[0,0]] };
+    jest.spyOn(RandomUtils, 'getRandomLevel').mockReturnValue(level);
+    const env = new Environment(1,1,1,1);
+    const player = new Player(env,0,0);
+    const keys = { enter: true };
+    const gold = player.capture(keys);
+    expect(gold).toEqual([0,0]);
+    expect(keys.enter).toBe(false);
+    RandomUtils.getRandomLevel.mockRestore();
+  });
+});
+
+describe('Player.update movement', () => {
+  test('changes direction then moves and resets keys', () => {
+    const level = { holes: [], wumpus: [], golds: [] };
+    jest.spyOn(RandomUtils, 'getRandomLevel').mockReturnValue(level);
+    const env = new Environment(2,2,1,1);
+    const player = new Player(env,0,0);
+    const keys = { right: true, up:false, down:false, left:false };
+    // first call only changes direction
+    let moved = player.update(keys);
+    expect(moved).toBe(false);
+    expect(player.direction).toBe(4); // right
+    expect(player.x).toBe(0);
+    // second call moves
+    keys.right = true;
+    moved = player.update(keys);
+    expect(moved).toBe(true);
+    expect(player.x).toBe(1);
+    // keys reset
+    expect(keys.right).toBe(false);
+    RandomUtils.getRandomLevel.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- export `Environment`, `Player`, and `Keys` for Node usage
- test environment initialization, restart and cleanup helpers
- test player combat, capture, and movement logic
- test keyboard onKeyDown flag setting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6847fd7e8de483258d0709af17e260b0